### PR TITLE
Update to 1.20

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,30 +10,24 @@ jobs:
   build:
     strategy:
       matrix:
-        # Use these Java versions
-        java: [
-          17,    # Current Java LTS & minimum supported by Minecraft
-        ]
-        # and run on both Linux and Windows
-        os: [ubuntu-20.04, windows-2022]
+        os: [ubuntu-20.04]
     runs-on: ${{ matrix.os }}
     steps:
       - name: checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: validate gradle wrapper
         uses: gradle/wrapper-validation-action@v1
       - name: setup jdk ${{ matrix.java }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
-          java-version: ${{ matrix.java }}
+          distribution: 'adopt'
+          java-version: 17
       - name: make gradle wrapper executable
-        if: ${{ runner.os != 'Windows' }}
         run: chmod +x ./gradlew
       - name: build
         run: ./gradlew build
       - name: capture build artifacts
-        if: ${{ runner.os == 'Linux' && matrix.java == '17' }} # Only upload artifacts built from latest java on one OS
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: Artifacts
           path: build/libs/

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,12 +3,12 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 	# check these on https://fabricmc.net/develop
-	minecraft_version=1.18.2
-	yarn_mappings=1.18.2+build.3
-	loader_version=0.14.6
+	minecraft_version=1.20.1
+	yarn_mappings=1.20.1+build.9
+	loader_version=0.14.21
 
 # Mod Properties
-	mod_version = 1.0.0
+	mod_version = 1.0.1
 	maven_group = artemis
 	archives_base_name = coyote_time
 

--- a/src/main/java/artemis/coyote_time/mixin/LivingEntityMixin.java
+++ b/src/main/java/artemis/coyote_time/mixin/LivingEntityMixin.java
@@ -30,7 +30,7 @@ public abstract class LivingEntityMixin extends Entity {
 
 	@Inject(method = "aiStep", at = @At(value = "HEAD"))
 	private void coyote_time_countTicksFalling(CallbackInfo ci) {
-		if (!this.onGround) {
+		if (!this.onGround()) {
 			ticksFalling++;
 		} else {
 			ticksFalling = 0;

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -23,8 +23,8 @@
 	],
 
 	"depends": {
-		"fabricloader": ">=0.14.6",
-		"minecraft": ">=1.18.2",
+		"fabricloader": "*",
+		"minecraft": ">=1.16",
 		"java": ">=17"
 	}
 }


### PR DESCRIPTION
Changes:
- Updates workflow to address deprecated Node.js 12 actions
- Sets target version to 1.20.1
- Replaces request to private `onGround` field with a call to `onGround()`
- Adjusts `fabric.mod.json` to match supported versions (I tested it, and it works in every version greater than 1.15)

I know you said you probably wouldn't merge it, but its been a week and I would like to have 1.20 on modrinth so I can recommend it to my friends again.